### PR TITLE
Put fragments in order

### DIFF
--- a/src/dom/after.js
+++ b/src/dom/after.js
@@ -14,6 +14,9 @@ define([ "shoestring" ], function(){
 			fragment = shoestring( fragment );
 		}
 
+		if( fragment.length > 1 ){
+			fragment = fragment.reverse();
+		}
 		return this.each(function( i ){
 			for( var j = 0, jl = fragment.length; j < jl; j++ ){
 				var insertEl = i > 0 ? fragment[ j ].cloneNode( true ) : fragment[ j ];

--- a/test/unit/extensions.js
+++ b/test/unit/extensions.js
@@ -49,6 +49,25 @@
 		});
 	});
 
+	test( '`.after()` inserts siblings after the current obj element in the correct order', function(){
+		expect( 6 );
+		var $element = $fixture.find( '.after' );
+
+		equal( $fixture.find( '.foo-after' ).length, 0 );
+		equal( $fixture.find( '.foo-after2' ).length, 0 );
+		$element.after( "<div class='foo-after'></div><div class='foo-after2'></div> ");
+		equal( $fixture.find( '.foo-after' ).length, 1 );
+		equal( $fixture.find( '.foo-after2' ).length, 1 );
+
+		// sibling to .foo-after
+		$fixture.children().each(function(i) {
+			if( shoestring( this ).is( '.after' ) ){
+				equal( $fixture.children()[i+1].className, "foo-after" );
+				equal( $fixture.children()[i+2].className, "foo-after2" );
+			}
+		});
+	});
+
 	test( '`.insertAfter()` inserts after the selector', function(){
 		expect( 3 );
 


### PR DESCRIPTION
After was broken in that it was putting the fragment dom nodes in out of
order if there was more than one. This fixes that.
