### PR TITLE
clone opts in order to be able to create multiple custom builds

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -15,14 +15,15 @@ module.exports = function(grunt) {
 
 	files.forEach(function( file ) {
 		if( /\.js$/.test(file) ){
-			var name = file.replace(/\.js$/, "");
+			var name = file.replace(/\.js$/, ""),
+				o = Object.create(opts);
 
 			builds[name] = {
-				options: opts
+				options: o
 			};
 
-			builds[name].options.name = opts.name.replace("REPLACE", "custom/" + name );
-			builds[name].options.out = opts.out.replace("REPLACE", name );
+			builds[name].options.name = o.name.replace("REPLACE", "custom/" + name );
+			builds[name].options.out = o.out.replace("REPLACE", name );
 		}
 	});
 


### PR DESCRIPTION
When the custom builds are created in the first iteration REPLACE is overridden by the filename from the first iteration. In the subsequent iterations it tries to replace 'REPLACE' but it is not there anymore. In order to create mutliple custom builds I clone the 'opts' in every iteration.
