### PR TITLE
if there is data to be sent pass it to req.send()

### DIFF
--- a/src/ajax/ajax.js
+++ b/src/ajax/ajax.js
@@ -69,7 +69,7 @@ define([ "shoestring" ], function(){
 			return req;
 		}
 
-		req.send( null );
+		req.send( settings.data || null );
 		return req;
 	};
 


### PR DESCRIPTION
The functionality for sending data with ajax post is added, which is nice. But was not passed to 'req.send()'
