### PR TITLE
Fix calling $.get() and $.post() without callback

### DIFF
--- a/src/ajax/ajax.js
+++ b/src/ajax/ajax.js
@@ -59,7 +59,7 @@ define([ "shoestring" ], function(){
 				else if ( req.status.toString().match( /^(4|5)/ ) && RegExp.$1 ){
 					return settings.error( res, req.status, req );
 				}
-				else {
+				else if (settings.success) {
 					return settings.success( res, req.status, req );
 				}
 			}


### PR DESCRIPTION
Without this fix, omitting the `callback` parameter causes an error because in the function `shoestring.ajax` the variable `settings.success` is undefined.

```
$.get('/')
Uncaught TypeError: undefined is not a function
```

```
$.post('/', {})
Uncaught TypeError: undefined is not a function
```