### PR TITLE
serialize.js: Node.nodeName uses uppercase

### DIFF
--- a/src/dom/serialize.js
+++ b/src/dom/serialize.js
@@ -41,7 +41,7 @@ define([ "shoestring" ], function(){
 					this.checked ){
 
 				data[ name ] = value;
-			}	else if( this.nodeName === "select" ){
+			}	else if( this.nodeName === "SELECT" ){
 				data[ name ] = this.options[ this.selectedIndex ].nodeValue;
 			}
 		});


### PR DESCRIPTION
At least in HTML5, see http://ejohn.org/blog/nodename-case-sensitivity/