### PR TITLE
update $.fn.get to return array if index isn't specified, relates to #80

### DIFF
--- a/src/dom/get.js
+++ b/src/dom/get.js
@@ -6,11 +6,23 @@ define([ "shoestring" ], function(){
 	 * Returns the raw DOM node at the passed index.
 	 *
 	 * @param {integer} index The index of the element to wrap and return.
-	 * @return HTMLElement
+	 * @return {HTMLElement|undefined|array}
 	 * @this shoestring
 	 */
 	shoestring.fn.get = function( index ){
-		return this[ index ];
+
+		// return an array of elements if index is undefined
+		if( index === undefined ){
+			var elements = [];
+
+			for( var i = 0; i < this.length; i++ ){
+				elements.push( this[ i ] );
+			}
+
+			return elements;
+		} else {
+			return this[ index ];
+		}
 	};
 
 //>>excludeStart("exclude", pragmas.exclude);


### PR DESCRIPTION
An array of HTMLElements will be returned if the index argument is not specified. 

