### PR TITLE
Data method and attrs

### DIFF
--- a/src/data/data.js
+++ b/src/data/data.js
@@ -2,6 +2,7 @@
 define([
 	"shoestring",
 //>>includeStart("development", pragmas.development);
+	// Note the use of nested pragmas here
 	"dom/is"
 //>>includeEnd("development");
 ], function(){

--- a/src/data/data.js
+++ b/src/data/data.js
@@ -30,7 +30,7 @@ define([
 			else {
 				if( this[ 0 ] ) {
 					if( this[ 0 ].shoestringData ) {
-						return this[ 0 ].shoestringData[ name ] || undefined;
+						return this[ 0 ].shoestringData[ name ];
 					}
 //>>includeStart("development", pragmas.development);
 					if( shoestring( this[ 0 ] ).is( "[data-" + name + "]" ) ){

--- a/src/data/data.js
+++ b/src/data/data.js
@@ -1,5 +1,8 @@
 //>>excludeStart("exclude", pragmas.exclude);
-define([ "shoestring" ], function(){
+define([
+	"shoestring",
+	"dom/attr",
+], function(){
 //>>excludeEnd("exclude");
 
 	/**
@@ -22,7 +25,12 @@ define([ "shoestring" ], function(){
 				});
 			}
 			else {
-				return this[ 0 ] && this[ 0 ].shoestringData ? this[ 0 ].shoestringData[ name ] : undefined;
+				if( this[ 0 ] ) {
+					if( this[ 0 ].shoestringData ) {
+						return this[ 0 ].shoestringData[ name ];
+					}
+					return shoestring( this[ 0 ] ).attr( "data-" + name ) || undefined;
+				}
 			}
 		}
 		else {

--- a/src/data/data.js
+++ b/src/data/data.js
@@ -1,7 +1,9 @@
 //>>excludeStart("exclude", pragmas.exclude);
 define([
 	"shoestring",
-	"dom/attr",
+//>>includeStart("development", pragmas.development);
+	"dom/is"
+//>>includeEnd("development");
 ], function(){
 //>>excludeEnd("exclude");
 
@@ -30,8 +32,7 @@ define([
 						return this[ 0 ].shoestringData[ name ] || undefined;
 					}
 //>>includeStart("development", pragmas.development);
-					var dataAlias = shoestring( this[ 0 ] ).attr( "data-" + name );
-					if( dataAlias || dataAlias === '' ){
+					if( shoestring( this[ 0 ] ).is( "[data-" + name + "]" ) ){
 						shoestring.error( 'data-attr-alias' );
 					}
 //>>includeEnd("development");

--- a/src/data/data.js
+++ b/src/data/data.js
@@ -1,10 +1,7 @@
 //>>excludeStart("exclude", pragmas.exclude);
 define([
 	"shoestring",
-//>>includeStart("development", pragmas.development);
-	// Note the use of nested pragmas here
-	"dom/is"
-//>>includeEnd("development");
+	"dom/is" // note this dependency is only used for a dev error
 ], function(){
 //>>excludeEnd("exclude");
 

--- a/src/data/data.js
+++ b/src/data/data.js
@@ -27,9 +27,14 @@ define([
 			else {
 				if( this[ 0 ] ) {
 					if( this[ 0 ].shoestringData ) {
-						return this[ 0 ].shoestringData[ name ];
+						return this[ 0 ].shoestringData[ name ] || undefined;
 					}
-					return shoestring( this[ 0 ] ).attr( "data-" + name ) || undefined;
+//>>includeStart("development", pragmas.development);
+					var dataAlias = shoestring( this[ 0 ] ).attr( "data-" + name );
+					if( dataAlias || dataAlias === '' ){
+						shoestring.error( 'data-attr-alias' );
+					}
+//>>includeEnd("development");
 				}
 			}
 		}

--- a/src/util/errors.js
+++ b/src/util/errors.js
@@ -9,6 +9,7 @@ define([ "shoestring" ], function(){
 			"ajax-url-query": "data with urls that have existing query params",
 			"click": "the click method. Try using trigger( 'click' ) instead.",
 			"css-get" : "getting computed attributes from the DOM.",
+			"data-attr-alias": "the data method aliased to `data-` DOM attributes.",
 			"has-class" : "the hasClass method. Try using .is( '.klassname' ) instead.",
 			"html-function" : "passing a function into .html. Try generating the html you're passing in an outside function",
 			"live-delegate" : "the .live or .delegate methods. Use .bind or .on instead.",

--- a/test/unit/extensions.js
+++ b/test/unit/extensions.js
@@ -152,6 +152,18 @@
 		strictEqual( $( '#el' ).data( "somekey" ), undefined, 'should be undefined on an nonempty result set with a key passed in.' );
 	});
 
+	test( '`.data` works with `data-` attributes', function() {
+		var $fixture = shoestring( '#qunit-fixture' ),
+			$el;
+
+		$fixture.html( '<div id="el" data-attr1 data-attr2="test"></div>' );
+		$el = $( "#el" );
+
+		strictEqual( $( '#el' ).data( "attr0" ), undefined, 'should alias to attr("data-attr0") (does not exist)' );
+		strictEqual( $( '#el' ).data( "attr1" ), undefined, 'should alias to attr("data-attr1"), has no value' );
+		strictEqual( $( '#el' ).data( "attr2" ), "test", 'should alias to attr("data-attr2"), has a value' );
+	});
+
 	test( '`.insertBefore()` inserts before the selector', function(){
 		expect( 3 );
 

--- a/test/unit/extensions.js
+++ b/test/unit/extensions.js
@@ -138,6 +138,23 @@
 		});
 	});
 
+	test( '`.data` and falsy values', function() {
+		var $fixture = shoestring( '#qunit-fixture' ),
+			$el;
+
+		$fixture.html( '<div id="el"></div>' );
+		$el = $( "#el" );
+
+		$el.data( "val-false", false );
+		strictEqual( $( '#el' ).data( "val-false" ), false );
+
+		$el.data( "val-zero", 0 );
+		strictEqual( $( '#el' ).data( "val-zero" ), 0 );
+
+		$el.data( "val-undefined", undefined );
+		strictEqual( $( '#el' ).data( "val-undefined" ), undefined );
+	});
+
 	test( '`.data` works on empty nodelists', function() {
 		var $fixture = shoestring( '#qunit-fixture' ),
 			$el;

--- a/test/unit/extensions.js
+++ b/test/unit/extensions.js
@@ -152,16 +152,23 @@
 		strictEqual( $( '#el' ).data( "somekey" ), undefined, 'should be undefined on an nonempty result set with a key passed in.' );
 	});
 
-	test( '`.data` works with `data-` attributes', function() {
+	test( '`.data` does not alias to `data-` attributes', function() {
+		expect( 3 );
 		var $fixture = shoestring( '#qunit-fixture' ),
 			$el;
 
 		$fixture.html( '<div id="el" data-attr1 data-attr2="test"></div>' );
 		$el = $( "#el" );
 
-		strictEqual( $( '#el' ).data( "attr0" ), undefined, 'should alias to attr("data-attr0") (does not exist)' );
-		strictEqual( $( '#el' ).data( "attr1" ), undefined, 'should alias to attr("data-attr1"), has no value' );
-		strictEqual( $( '#el' ).data( "attr2" ), "test", 'should alias to attr("data-attr2"), has a value' );
+		strictEqual( $( '#el' ).data( "attr0" ), undefined, 'attribute does not exist, should not throw an error.' );
+
+		throws(function() {
+			$( '#el' ).data( "attr1" );
+		}, 'attribute exists but has no value, should have thrown a dev error.' );
+
+		throws(function() {
+			$( '#el' ).data( "attr2" );
+		}, 'attribute exists and has a value, should have thrown a dev error.' );
 	});
 
 	test( '`.insertBefore()` inserts before the selector', function(){


### PR DESCRIPTION
X-rayHTML was using the jQuery convenience of aliasing `$.fn.data` to actual data DOM attributes.

For example, `<div data-test="value"></div>` would be accessible by `$('div').data('test')`

I’ve added a DEV error if accesses like that are made (when the key doesn’t exist but the DOM attribute of the same name does).