### PR TITLE
Fix TypeError when calling "val()" on empty list

### DIFF
--- a/src/dom/val.js
+++ b/src/dom/val.js
@@ -39,7 +39,7 @@ define([ "shoestring" ], function(){
 					this.value = value;
 				}
 			});
-		} else {
+		} else if (this[0]) {
 			el = this[0];
 
 			if( el.tagName === "SELECT" ){


### PR DESCRIPTION
Fixes "Uncaught TypeError: Cannot read property 'tagName' of undefined" when calling `$('non-existent-selector').val()`.