### PR TITLE
siblings works with detached nodes

### DIFF
--- a/src/dom/siblings.js
+++ b/src/dom/siblings.js
@@ -19,15 +19,17 @@ define([ "shoestring" ], function(){
 			return shoestring( [] );
 		}
 
-		var sibs = [], el = this[ 0 ].parentNode.firstChild;
+		var sibs = [], el;
 
-		do {
+		el = (this[ 0 ].parentNode || {}).firstChild;
+
+		while( el ) {
 			if( el.nodeType === 1 && el !== this[ 0 ] ) {
 				sibs.push( el );
 			}
 
       el = el.nextSibling;
-		} while( el );
+		}
 
 		return shoestring( sibs );
 	};

--- a/test/unit/extensions.js
+++ b/test/unit/extensions.js
@@ -712,6 +712,9 @@
 
 		strictEqual( $( '#imaginary_element' ).siblings().length, 0, '.siblings runs on an empty set.' );
 		equal( $( '#sibling' ).siblings().length, 2, '.siblings returns non-empty set.' );
+
+		$fixture = $( '<div></div>' );
+		equal($fixture.siblings().length, 0, '.siblings returns empty set for detached');
 	});
 
 	test( '`.text()` returns content properly', function(){


### PR DESCRIPTION
Fix "necessary" for dialog a11y test failures. 